### PR TITLE
Update coefficients inplace and only save sub-samples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ function inference(observations;
     T = maximum(observations), # end time
     n = 1, # number of aggregated samples in `observations`
     N = min(length(observations)÷4, 50), # number of bins
-    IT = 30000, # number of iterations
+    samples = 1:1:30000, # run for `i in 1:last(samples)` iterations, save coefficients if `i ∈ samples`
     α1 = 0.1, β1 = 0.1, # parameters for Gamma Markov chain
     Π = Exponential(10), # prior on alpha
     τ = 0.7, # Set scale for random walk update on log(α)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ function inference(observations;
 )
 ```
 
-Iterates of *ψ* are obtained from
+Iterates of *ψ* are the rows of the matrix
 ```julia
 res.ψ
 ```
@@ -90,13 +90,13 @@ After installing the additional dependencies
 pkg> add RCall
 pkg> add DataFrames
 ```
-include the script (it is located in the `contrib` folder, the location can be retrieved by calling `PointProcessInference.plotscript()`) 
+include the script (it is located in the `contrib` folder, the location can be retrieved by calling `PointProcessInference.plotscript()`)
 ```
 include(PointProcessInference.plotscript())
 plotposterior(res)
 ```
 
-The script starts `ggplot2` with `RCall`, and `plotposterior` expects as its argument the result `res` returned from `inference`. For computing the posterior summary measures, the first half of the mcmc iterates are treated as burnin samples. 
+The script starts `ggplot2` with `RCall`, and `plotposterior` expects as its argument the result `res` returned from `inference`. For computing the posterior summary measures, the first half of the mcmc iterates are treated as burnin samples.
 
 ## Example 1
 
@@ -111,7 +111,7 @@ The nonparametric estimator is obtained by running
 ```julia
 res = PointProcessInference.inference(obs)
 ```
-Finally, a default graph is obtained by 
+Finally, a default graph is obtained by
 ```julia
 include(PointProcessInference.plotscript())
 plotposterior(res)
@@ -131,8 +131,8 @@ This results in the plot
 
 ## Example 2
 
-Here, we analyse the well knwon coal mining disasters data set. 
-```julia 
+Here, we analyse the well knwon coal mining disasters data set.
+```julia
 observations, parameters, λinfo = PointProcessInference.loadexample("coal")
 res = PointProcessInference.inference(observations)
 plotposterior(res)
@@ -143,7 +143,7 @@ plotposterior(res)
 * Illustration: Intensity estimation for the UK coal mining disasters data (1851-1962). The data are displayed via the rug plot in the upper margin of the plot, the posterior mean is given by a solid black line, while a 95% marginal credible band is shaded in light blue.
 
 The horizontal tickmarks can be adjusted, as the offset date of the data, which is March 15, 1851 in this case.
-```julia 
+```julia
 start = 1851+(28+31+15)/365
 plotposterior(res; figtitle="Coal mining disasters", offset = start,hortics=1850:10:1960)
 ```

--- a/src/funs-ig.jl
+++ b/src/funs-ig.jl
@@ -59,7 +59,7 @@ function counts_sorted(xx, grid)
 ################# functions for updating
 
 """
-    updateψ
+    updateψ!
 
 Sample from the distribution of ψ, conditional on ζ, αψ and αζ.
 
@@ -86,7 +86,7 @@ function updateψ!(ψ, H::Array{Int64}, Δ::AbstractArray, n::Integer, ζ::Abstr
 end
 
 """
-    updateζ
+    updateζ!
 
 Sample from the distribution of ζ, conditional on ψ, αψ and αζ.
 
@@ -95,7 +95,7 @@ Arguments:
 - αψ
 - αζ
 """
-function updateζ(ζ, ψ::AbstractArray, αψ, αζ)
+function updateζ!(ζ, ψ::AbstractArray, αψ, αζ)
     N = length(ψ)
     for k in 2:N
         ζ[k-1] = rand(InverseGamma(αψ + αζ, αζ*ψ[k-1] + αψ*ψ[k]))

--- a/src/ppp.jl
+++ b/src/ppp.jl
@@ -61,11 +61,14 @@ function inference(observations;
 
     # Initialise, by drawing under independence prior
     post_ind = zeros(N, 2)
-    for k in 1:N
-    	post_ind[k,:] = [αind + H[k], βind + n*Δ[k]]  # note that second parameter is the rate
-    	ψc = rand(Gamma(post_ind[k,1], 1.0/(post_ind[k,2])))
-    end
+    ψc = zeros(N)
     ζc = zeros(N-1)
+
+    for k in 1:N
+    	post_ind[k,:] = αind + H[k], βind + n*Δ[k]  # note that second parameter is the rate
+    	ψc[k] = rand(Gamma(post_ind[k,1], 1.0/(post_ind[k,2])))
+    end
+
 
     ss = 1 # keep track of subsample number
     if 1 in samples

--- a/src/ppp.jl
+++ b/src/ppp.jl
@@ -10,7 +10,7 @@ function inference(observations;
     T = maximum(observations), # end time
     n = 1, # number of aggregated samples in `observations`
     N = min(length(observations)÷4, 50), # number of bins
-    IT = 30000, # number of iterations
+    samples = 1:1:30000, # (sub-)samples to save
     α1 = 0.1, β1 = 0.1, # parameters for Gamma Markov chain
     Π = Exponential(10), # prior on alpha
     τ = 0.7, # Set scale for random walk update on log(α)
@@ -47,27 +47,42 @@ function inference(observations;
 
 
     ################### Initialisation of algorithms
+    first(samples) < 1 && throw(ArgumentError("first(samples) < 1)"))
+    SUBIT = length(samples)
+    IT = last(samples)
 
     # nr of iterations
-    ψ = zeros(IT, N)  # each row is an iteration
-    ζ = zeros(IT - 1, N)
+    ψ = zeros(SUBIT, N)  # each row is a (sub-) iteration
+    ζ = zeros(SUBIT - 1, N-1)
     α = zeros(IT)
-    α[1] = 1.0  # initial value for α
+    αc = 1.0
+    α[1] = αc  # initial value for α
     acc = zeros(Bool, IT - 1)  # keep track of MH acceptance
 
     # Initialise, by drawing under independence prior
     post_ind = zeros(N, 2)
     for k in 1:N
     	post_ind[k,:] = [αind + H[k], βind + n*Δ[k]]  # note that second parameter is the rate
-    	ψ[1,k] = rand(Gamma(post_ind[k,1], 1.0/(post_ind[k,2])))
+    	ψc = rand(Gamma(post_ind[k,1], 1.0/(post_ind[k,2])))
+    end
+    ss = 1
+    if 1 in samples
+        ψ[ss, :] = ψc
+        ss += 1
     end
 
     # Gibbs sampler
-    tt = @elapsed for i in 1:(IT-1)
-        αψ = αζ = α[i]
-        ζ[i,:] = updateζ(ψ[i,:], αψ, αζ)
-        ψ[i+1,:] = updateψ(H, Δ, n, ζ[i,:], αψ, αζ, α1, β1)
-        α[i+1], acc[i] = updateα(α[i], ψ[i + 1,:], ζ[i,:], τ,  Π)
+    tt = @elapsed for i in 2:IT
+        αψ = αζ = αc
+        updateζ!(ζc, ψc, αψ, αζ)
+        updateψ!(ψc, H, Δ, n, ζc, αψ, αζ, α1, β1)
+        α[i], acc[i] = updateα(αc, ψc, ζc, τ, Π)
+        αc = α[i]
+        if i in samples
+            ψ[ss,:] = ψc
+            ζ[ss,:] = ζc
+            ss += 1
+        end
     end
 
     if verbose

--- a/src/ppp.jl
+++ b/src/ppp.jl
@@ -65,9 +65,12 @@ function inference(observations;
     	post_ind[k,:] = [αind + H[k], βind + n*Δ[k]]  # note that second parameter is the rate
     	ψc = rand(Gamma(post_ind[k,1], 1.0/(post_ind[k,2])))
     end
-    ss = 1
+    ζc = zeros(N-1)
+
+    ss = 1 # keep track of subsample number
     if 1 in samples
         ψ[ss, :] = ψc
+        ψ[ss, :] = ζc # just saves zeros though
         ss += 1
     end
 

--- a/src/ppp.jl
+++ b/src/ppp.jl
@@ -65,7 +65,8 @@ function inference(observations;
     ζc = zeros(N-1)
 
     for k in 1:N
-    	post_ind[k,:] = αind + H[k], βind + n*Δ[k]  # note that second parameter is the rate
+    	post_ind[k,1] = αind + H[k]
+        post_ind[k,2] = βind + n*Δ[k]  # note that second parameter is the rate
     	ψc[k] = rand(Gamma(post_ind[k,1], 1.0/(post_ind[k,2])))
     end
 
@@ -73,7 +74,6 @@ function inference(observations;
     ss = 1 # keep track of subsample number
     if 1 in samples
         ψ[ss, :] = ψc
-        ψ[ss, :] = ζc # just saves zeros though
         ss += 1
     end
 
@@ -82,11 +82,11 @@ function inference(observations;
         αψ = αζ = αc
         updateζ!(ζc, ψc, αψ, αζ)
         updateψ!(ψc, H, Δ, n, ζc, αψ, αζ, α1, β1)
-        α[i], acc[i] = updateα(αc, ψc, ζc, τ, Π)
+        α[i], acc[i-1] = updateα(αc, ψc, ζc, τ, Π)
         αc = α[i]
         if i in samples
             ψ[ss,:] = ψc
-            ζ[ss,:] = ζc
+            ζ[ss - 1,:] = ζc
             ss += 1
         end
     end


### PR DESCRIPTION
This changes the code as follows:

* The functions `updateψ!` and `updateζ!` now update their argument in place.

* Instead of saving all iterations, the user provides the range `samples`. The algorithm runs for `i in 1:last(samples)` iterations and saves coefficients if `i ∈ samples`.

* The first element of `ζ` was never accessed, I made `ζ` a vector of `N-1` indices and shifted everything.